### PR TITLE
[OpenAPI/Send] [BugFix] - Fix undefined id on creating SendMessage record in /send endpoint handler

### DIFF
--- a/app/api/.eslintrc.js
+++ b/app/api/.eslintrc.js
@@ -36,4 +36,5 @@ module.exports = {
       },
     ],
   },
+  'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
 };

--- a/app/api/.eslintrc.js
+++ b/app/api/.eslintrc.js
@@ -36,5 +36,4 @@ module.exports = {
       },
     ],
   },
-  'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
 };

--- a/app/api/app-worker.js
+++ b/app/api/app-worker.js
@@ -85,7 +85,7 @@ const { log: consoleLog } = console;
               });
 
               await SendMessageLogEntity.create({
-                response: JSON.stringify(result.resp),
+                response: JSON.stringify(result.response),
                 SendMessageId: sendMessage.id,
               });
 

--- a/app/api/src/OpenAPI/Send.js
+++ b/app/api/src/OpenAPI/Send.js
@@ -53,16 +53,16 @@ class Send {
         Object.keys(validPhones).forEach((mobile) => {
           promises.push(
             new Promise((resolve) => {
-              const m = SendMessageEntity.create({
+              SendMessageEntity.create({
                 mobile,
                 // eslint-disable-next-line security/detect-object-injection
                 country: validPhones[mobile],
                 user: req.raw.user.id,
                 message: req.body.message,
-              }).then(() => {
+              }).then((message) => {
                 // eslint-disable-next-line security/detect-object-injection
                 results.push({
-                  id: m.id,
+                  id: message.id,
                   mobile,
                 });
                 resolve();

--- a/app/api/test/test/OpenAPI/Send.spec.js
+++ b/app/api/test/test/OpenAPI/Send.spec.js
@@ -48,6 +48,17 @@ describe(__filename.replace(__dirname, ''), () => {
     });
 
     expect(resp.statusCode).toBe(200);
+    expect(resp.payload).not.toBeFalsy();
+
+    payload = JSON.parse(resp.payload);
+    expect(payload).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: expect.any(Number),
+          mobile: expect.any(String),
+        }),
+      ]),
+    );
 
     resp = await fastify.inject({
       url: fastify.openAPIBaseURL('/send'),
@@ -62,5 +73,16 @@ describe(__filename.replace(__dirname, ''), () => {
     });
 
     expect(resp.statusCode).toBe(200);
+    expect(resp.payload).not.toBeFalsy();
+
+    payload = JSON.parse(resp.payload);
+    expect(payload).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: expect.any(Number),
+          mobile: expect.any(String),
+        }),
+      ]),
+    );
   });
 });


### PR DESCRIPTION
fixes #1 

There was a problem with the /send endpoint handler on creating the SendMessage record promise.
The promise was not handled properly, so the `.then()` method didn't have access to the created record unique id and the `id` was always `undefined` and also was omitted from the `results` array

- Fixed /send endpoint issue
- Fixed related tests
- Fixed `resp` typo in app-worker.js on line 88. (`resp` modified to `response`)
- Fixed eslint error on devDependencies